### PR TITLE
GBA internal names can contain spaces. Fixes #6.

### DIFF
--- a/WiiuVcExtractor/RomExtractors/GbaVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/GbaVcExtractor.cs
@@ -152,7 +152,7 @@ namespace WiiuVcExtractor.RomExtractors
                 // Ensure the title is set to valid characters
                 for (int i = HEADER_TITLE_OFFSET; i < HEADER_TITLE_OFFSET + HEADER_TITLE_LENGTH; i++)
                 {
-                    if ((gbaHeader[i] < ASCII_ZERO || gbaHeader[i] > ASCII_Z) && gbaHeader[i] != 0x00 )
+                    if ((gbaHeader[i] < ASCII_ZERO || gbaHeader[i] > ASCII_Z) && gbaHeader[i] != 0x00 && gbaHeader[i] != ASCII_SPACE)
                     {
                         return false;
                     }


### PR DESCRIPTION
Super Mario Advance 4 has an internal name of "SUPER MARIOD", but spaces were considered invalid by `GbaVcExtractor.IsValidRom()`.

May also fix issues #9 and #10.