### PR TITLE
Fix GBA header check and improve logging

### DIFF
--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -8,7 +8,7 @@ namespace WiiuVcExtractor
 {
     class Program
     {
-        private const string WIIU_VC_EXTRACTOR_VERSION = "0.4.0";
+        private const string WIIU_VC_EXTRACTOR_VERSION = "0.4.1";
 
         static void PrintUsage()
         {


### PR DESCRIPTION
This improves the GBA header check so that it no longer checks the first 4 bytes (these are actually part of the ROM entry point, not the GBA bitmap). It also adds more logging to accelerate future troubleshooting.

Fixes #17 