### PR TITLE
Make GBA title check more permissive (allow 0x20 to 0x7E)

### DIFF
--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -8,7 +8,7 @@ namespace WiiuVcExtractor
 {
     class Program
     {
-        private const string WIIU_VC_EXTRACTOR_VERSION = "0.4.1";
+        private const string WIIU_VC_EXTRACTOR_VERSION = "0.4.2";
 
         static void PrintUsage()
         {

--- a/WiiuVcExtractor/RomExtractors/GbaVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/GbaVcExtractor.cs
@@ -41,6 +41,7 @@ namespace WiiuVcExtractor.RomExtractors
         private const byte ASCII_SPACE = 0x20;
         private const byte ASCII_ZERO = 0x30;
         private const byte ASCII_Z = 0x5A;
+        private const byte ASCII_TILDE = 0x7E;
 
         private PsbFile psbFile;
         private RomNameDictionary gbaDictionary;
@@ -181,7 +182,7 @@ namespace WiiuVcExtractor.RomExtractors
                         Console.WriteLine("Title Character[{0}]: {1}", i, Convert.ToChar(gbaHeader[i]));
                     }
 
-                    if ((gbaHeader[i] < ASCII_SPACE || gbaHeader[i] > ASCII_Z) && gbaHeader[i] != 0x00)
+                    if ((gbaHeader[i] < ASCII_SPACE || gbaHeader[i] > ASCII_TILDE) && gbaHeader[i] != 0x00)
                     {
                         if (verbose)
                         {


### PR DESCRIPTION
This makes the GBA title check accept all ASCII characters from space to tilde as possible valid title characters. Fixes #19 

[wiiu-vc-extractor-0.4.2-rc1.zip](https://github.com/wheatevo/wiiu-vc-extractor/files/1290156/wiiu-vc-extractor-0.4.2-rc1.zip)
