### PR TITLE
Fix invalid GBA header entry points

### DIFF
--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -8,7 +8,7 @@ namespace WiiuVcExtractor
 {
     class Program
     {
-        private const string WIIU_VC_EXTRACTOR_VERSION = "0.4.2";
+        private const string WIIU_VC_EXTRACTOR_VERSION = "0.4.3";
 
         static void PrintUsage()
         {


### PR DESCRIPTION
This change ensures that the GBA entry point is set to `0x2E 0x00 0x00 0xEA` as expected. Some VC roms do not appear to have valid entry points.

Fixes #21 