### PR TITLE
Implement Support for Famicom Disk System Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Modification of vc extractor to allow invalid nes games to pass verification (Lost Levels)
+
 # wiiu-vc-extractor
 Extracts Wii U Virtual Console roms from dumps created via [DDD](https://github.com/dimok789/ddd/releases) or from the SNES Mini.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # wiiu-vc-extractor
 Extracts Wii U Virtual Console roms from dumps created via [DDD](https://github.com/dimok789/ddd/releases) or from the SNES Mini.
 
-This currently only supports extracting GBA, NES, and SNES roms. Note that most VC titles are not clean roms but have been modified from their original state.
+This currently only supports extracting GBA, NES, and SNES roms. 
+# Note:
+- Most VC titles are not clean roms but have been modified from their original state
+- Famicom Disk System games are not playable, but can be edited to be playable.
 
 ## Installation
 ### Windows

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wiiu-vc-extractor
 Extracts Wii U Virtual Console roms from dumps created via [DDD](https://github.com/dimok789/ddd/releases) or from the SNES Mini.
 
-This currently only supports extracting GBA, NES, and SNES roms. 
+This currently only supports extracting GBA, NES, FDS, and SNES roms. 
 # Note:
 - Most VC titles are not clean roms but have been modified from their original state
 - Famicom Disk System games are not playable, but can be edited to be playable.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Extracts Wii U Virtual Console roms from dumps created via [DDD](https://github.
 
 This currently only supports extracting GBA, NES, FDS, and SNES roms. 
 # Note:
-- Most VC titles are not clean roms but have been modified from their original state
+- Most VC titles are not clean roms but have been modified from their original state.
 - Famicom Disk System games are not playable, but can be edited to be playable.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -80,6 +80,36 @@ WUP-FCSE.rpx has been extracted to MEGA MAN 6.nes successfully.
 ============================================================================
 ```
 
+### FDS Extraction
+```
+WiiuVcExtractor.exe WUP-FA9E.rpx
+============================================================================
+Starting extraction of rom from WUP-FA9E.rpx...
+============================================================================
+RPX file detected!
+Decompressing RPX file...
+Decompression complete.
+Checking if this is an NES VC title...
+Checking WUP-FA9E.rpx.extract...
+Not an NES VC Title
+Checking if this is an SNES VC title...
+Checking WUP-FA9E.rpx.extract...
+Checking for the SNES WUP header
+Not an SNES VC Title
+Checking if this is a Famicom Disk System VC title...
+Checking WUP-FA9E.rpx.extract...
+Famicom Disk System Rom Detected!
+Virtual Console Title: WUP-FA9E
+FDS Title: Super Mario Bros The Lost Levels
+Total FDS rom size: 65500 Bytes
+Getting rom data...
+Writing to Super Mario Bros The Lost Levels.fds...
+Writing rom data...
+============================================================================
+Famicom Disk System rom has been created successfully at Super Mario Bros The Lost Levels.fds
+============================================================================
+```
+
 ### SNES Extraction (rpx)
 ```
 ============================================================================

--- a/WiiuVcExtractor/FileTypes/RpxFile.cs
+++ b/WiiuVcExtractor/FileTypes/RpxFile.cs
@@ -94,9 +94,7 @@ namespace WiiuVcExtractor.FileTypes
             }
 
             sectionHeaderIndices = new List<RpxSectionHeaderSort>();
-            // From 0x31 in *.rpx.extract, should have capacity of 0x1E or 30
             sectionHeaders = new List<RpxSectionHeader>(header.SectionHeaderCount);
-            // From 0x31 in *.rpx.extract, should have capacity of 0x1E or 30
             crcs = new List<uint>(header.SectionHeaderCount);
 
             if (verbose)
@@ -108,11 +106,10 @@ namespace WiiuVcExtractor.FileTypes
             {
                 using (BinaryReader br = new BinaryReader(fs, new ASCIIEncoding()))
                 {
-                    // Seek to the Section Header Offset in the file,
-                    // should be offset 0x23
+                    // Seek to the Section Header Offset in the file
                     br.BaseStream.Seek(header.SectionHeaderOffset,SeekOrigin.Begin);
 
-                    // Read in all of the section headers - 30 of them
+                    // Read in all of the section headers
                     for (UInt32 i = 0; i < header.SectionHeaderCount; i++)
                     {
                         crcs.Add(0);
@@ -148,15 +145,6 @@ namespace WiiuVcExtractor.FileTypes
 
             sectionHeaderIndices.Sort();
 
-            // THIS handles the decompression and where FDS *.rpx.extract gets 
-            // messed up
-            //
-            // sectionHeaderIndices[2] / sectionHeaders[3] begins at the start 
-            // of the game data, offset 0x6C0 (for FDS/NES games)
-            // and end is at offset 0x249BC4, before 24-byte-long series of zeros
-            //
-            // decompression of gamedata occurs at i=2, where if statement is true
-            //
             // Iterate through all of the section header indices
             for (int i = 0; i < sectionHeaderIndices.Count; i++)
             {
@@ -177,8 +165,6 @@ namespace WiiuVcExtractor.FileTypes
 
                         currentSectionHeader.Offset = (uint)br.BaseStream.Position;
 
-                        // Bitwise comparison of Flags and SECTION_HEADER_RPL_ZLIB, 
-                        // then comparison of result to SECTION_HEADER_RPL_ZLIB
                         if ((currentSectionHeader.Flags & RpxSectionHeader.SECTION_HEADER_RPL_ZLIB) == RpxSectionHeader.SECTION_HEADER_RPL_ZLIB)
                         {
                             UInt32 dataSize = currentSectionHeader.Size - 4;

--- a/WiiuVcExtractor/FileTypes/RpxFile.cs
+++ b/WiiuVcExtractor/FileTypes/RpxFile.cs
@@ -52,7 +52,7 @@ namespace WiiuVcExtractor.FileTypes
 
             header = new RpxHeader(path);
 
-            // Begins writing header to *.rpx.extract
+            // Begin writing header to *.rpx.extract
             using (FileStream fs = new FileStream(decompressedPath, FileMode.OpenOrCreate, FileAccess.Write))
             {
                 using (BinaryWriter bw = new BinaryWriter(fs, new ASCIIEncoding()))

--- a/WiiuVcExtractor/FileTypes/RpxFile.cs
+++ b/WiiuVcExtractor/FileTypes/RpxFile.cs
@@ -6,7 +6,6 @@ using Ionic.Zlib;
 
 using WiiuVcExtractor.Libraries;
 
-
 namespace WiiuVcExtractor.FileTypes
 {
     public class RpxFile
@@ -53,7 +52,6 @@ namespace WiiuVcExtractor.FileTypes
 
             header = new RpxHeader(path);
 
-            // Begin writing header to *.rpx.extract
             using (FileStream fs = new FileStream(decompressedPath, FileMode.OpenOrCreate, FileAccess.Write))
             {
                 using (BinaryWriter bw = new BinaryWriter(fs, new ASCIIEncoding()))
@@ -77,14 +75,11 @@ namespace WiiuVcExtractor.FileTypes
                     EndianUtility.WriteUInt32BE(bw, 0x00000000);
                     EndianUtility.WriteUInt32BE(bw, 0x00000000);
 
-                    // write zeros up to offset SectionHeaderDataElfOffset
                     while ((ulong)bw.BaseStream.Position < header.SectionHeaderDataElfOffset)
                     {
                         bw.Write((byte)0);
                     }
 
-                    // continue writing zeros until an offset that is a multiple
-                    // of 64 is reached
                     while (bw.BaseStream.Position % 0x40 != 0)
                     {
                         bw.Write((byte)0);
@@ -114,11 +109,10 @@ namespace WiiuVcExtractor.FileTypes
                     {
                         crcs.Add(0);
 
-                        // Read in 40 bytes for the section header
+                        // Read in the bytes for the section header
                         byte[] buffer = br.ReadBytes(RpxSectionHeader.SECTION_HEADER_LENGTH);
 
-                        // Create a new section header using the 40 byte buffer
-                        // and add it to the sectionHeaders list
+                        // Create a new section header and add it to the list
                         RpxSectionHeader newSectionHeader = new RpxSectionHeader(buffer);
                         sectionHeaders.Add(newSectionHeader);
 
@@ -178,7 +172,6 @@ namespace WiiuVcExtractor.FileTypes
                             compressor.InitializeInflate(true);
                             compressor.AvailableBytesIn = 0;
                             compressor.NextIn = 0;
-
 
                             while (dataSize > 0)
                             {

--- a/WiiuVcExtractor/FileTypes/RpxFile.cs
+++ b/WiiuVcExtractor/FileTypes/RpxFile.cs
@@ -52,6 +52,7 @@ namespace WiiuVcExtractor.FileTypes
 
             header = new RpxHeader(path);
 
+            // Begins writing header to *.rpx.extract
             using (FileStream fs = new FileStream(decompressedPath, FileMode.OpenOrCreate, FileAccess.Write))
             {
                 using (BinaryWriter bw = new BinaryWriter(fs, new ASCIIEncoding()))

--- a/WiiuVcExtractor/FileTypes/RpxHeader.cs
+++ b/WiiuVcExtractor/FileTypes/RpxHeader.cs
@@ -60,31 +60,31 @@ namespace WiiuVcExtractor.FileTypes
                     //
                     // read first 16 bytes
                     identity = br.ReadBytes(ELF_SIGNATURE_LENGTH);
-                    // read next 2 bytes (offsets 0x10 and 0x11)
+                    // read offsets 0x10 0x11
                     type = EndianUtility.ReadUInt16BE(br);
-                    // read offset 0x13
+                    // read offsets 0x12 0x13
                     machine = EndianUtility.ReadUInt16BE(br);
-                    // read offset 0x17
+                    // read offsets 0x14 0x15 0x16 0x17
                     version = EndianUtility.ReadUInt32BE(br);
-                    // read offsets 0x18 through 0x1B
+                    // read offsets 0x18 0x19 0x1A 0x1B
                     entryPoint = EndianUtility.ReadUInt32BE(br);
-                    // read ? (the value is zero)
+                    // read offsets 0x1C 0x1D 0x1E 0x1F (the value is zero)
                     phOffset = EndianUtility.ReadUInt32BE(br);
-                    // read offset 0x23 - value should be 0x40 / 64
+                    // read offsets 0x20 0x21 0x22 0x23 - value should be 0x40 / 64
                     shOffset = EndianUtility.ReadUInt32BE(br);
-                    // read ? (the value is zero)
+                    // read offsets 0x24 0x25 0x26 0x27 (the value is zero)
                     flags = EndianUtility.ReadUInt32BE(br);
-                    // read offset 0x29
+                    // read offsets 0x28 0x29
                     ehSize = EndianUtility.ReadUInt16BE(br);
-                    // read ? (the value is zero)
+                    // read offsets 0x2A 0x2B (the value is zero)
                     phEntSize = EndianUtility.ReadUInt16BE(br);
-                    // read ? (the value is zero)
+                    // read offsets 0x2C 0x2D (the value is zero)
                     phNum = EndianUtility.ReadUInt16BE(br);
-                    // read offset 0x2F
+                    // read offsets 0x2E 0x2F
                     shEntSize = EndianUtility.ReadUInt16BE(br);
-                    // read offset 0x31
+                    // read offsets 0x30 0x31 - value 30
                     shNum = EndianUtility.ReadUInt16BE(br);
-                    // read offset 0x33
+                    // read offsets 0x32 0x33
                     shStrIndex = EndianUtility.ReadUInt16BE(br);
                 }
             }

--- a/WiiuVcExtractor/FileTypes/RpxHeader.cs
+++ b/WiiuVcExtractor/FileTypes/RpxHeader.cs
@@ -57,19 +57,34 @@ namespace WiiuVcExtractor.FileTypes
                 using (BinaryReader br = new BinaryReader(fs, new ASCIIEncoding()))
                 {
                     // Read in the header
+                    //
+                    // read first 16 bytes
                     identity = br.ReadBytes(ELF_SIGNATURE_LENGTH);
+                    // read next 2 bytes (offsets 0x10 and 0x11)
                     type = EndianUtility.ReadUInt16BE(br);
+                    // read offset 0x13
                     machine = EndianUtility.ReadUInt16BE(br);
+                    // read offset 0x17
                     version = EndianUtility.ReadUInt32BE(br);
+                    // read offsets 0x18 through 0x1B
                     entryPoint = EndianUtility.ReadUInt32BE(br);
+                    // read ? (the value is zero)
                     phOffset = EndianUtility.ReadUInt32BE(br);
+                    // read offset 0x23
                     shOffset = EndianUtility.ReadUInt32BE(br);
+                    // read ? (the value is zero)
                     flags = EndianUtility.ReadUInt32BE(br);
+                    // read offset 0x29
                     ehSize = EndianUtility.ReadUInt16BE(br);
+                    // read ? (the value is zero)
                     phEntSize = EndianUtility.ReadUInt16BE(br);
+                    // read ? (the value is zero)
                     phNum = EndianUtility.ReadUInt16BE(br);
+                    // read offset 0x2F
                     shEntSize = EndianUtility.ReadUInt16BE(br);
+                    // read offset 0x31
                     shNum = EndianUtility.ReadUInt16BE(br);
+                    // read offset 0x33
                     shStrIndex = EndianUtility.ReadUInt16BE(br);
                 }
             }

--- a/WiiuVcExtractor/FileTypes/RpxHeader.cs
+++ b/WiiuVcExtractor/FileTypes/RpxHeader.cs
@@ -57,34 +57,19 @@ namespace WiiuVcExtractor.FileTypes
                 using (BinaryReader br = new BinaryReader(fs, new ASCIIEncoding()))
                 {
                     // Read in the header
-                    //
-                    // read first 16 bytes
                     identity = br.ReadBytes(ELF_SIGNATURE_LENGTH);
-                    // read offsets 0x10 0x11
                     type = EndianUtility.ReadUInt16BE(br);
-                    // read offsets 0x12 0x13
                     machine = EndianUtility.ReadUInt16BE(br);
-                    // read offsets 0x14 0x15 0x16 0x17
                     version = EndianUtility.ReadUInt32BE(br);
-                    // read offsets 0x18 0x19 0x1A 0x1B
                     entryPoint = EndianUtility.ReadUInt32BE(br);
-                    // read offsets 0x1C 0x1D 0x1E 0x1F (the value is zero)
                     phOffset = EndianUtility.ReadUInt32BE(br);
-                    // read offsets 0x20 0x21 0x22 0x23 - value should be 0x40 / 64
                     shOffset = EndianUtility.ReadUInt32BE(br);
-                    // read offsets 0x24 0x25 0x26 0x27 (the value is zero)
                     flags = EndianUtility.ReadUInt32BE(br);
-                    // read offsets 0x28 0x29
                     ehSize = EndianUtility.ReadUInt16BE(br);
-                    // read offsets 0x2A 0x2B (the value is zero)
                     phEntSize = EndianUtility.ReadUInt16BE(br);
-                    // read offsets 0x2C 0x2D (the value is zero)
                     phNum = EndianUtility.ReadUInt16BE(br);
-                    // read offsets 0x2E 0x2F
                     shEntSize = EndianUtility.ReadUInt16BE(br);
-                    // read offsets 0x30 0x31 - value 30
                     shNum = EndianUtility.ReadUInt16BE(br);
-                    // read offsets 0x32 0x33
                     shStrIndex = EndianUtility.ReadUInt16BE(br);
                 }
             }

--- a/WiiuVcExtractor/FileTypes/RpxHeader.cs
+++ b/WiiuVcExtractor/FileTypes/RpxHeader.cs
@@ -70,7 +70,7 @@ namespace WiiuVcExtractor.FileTypes
                     entryPoint = EndianUtility.ReadUInt32BE(br);
                     // read ? (the value is zero)
                     phOffset = EndianUtility.ReadUInt32BE(br);
-                    // read offset 0x23
+                    // read offset 0x23 - value should be 0x40 / 64
                     shOffset = EndianUtility.ReadUInt32BE(br);
                     // read ? (the value is zero)
                     flags = EndianUtility.ReadUInt32BE(br);

--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -84,9 +84,7 @@ namespace WiiuVcExtractor
             PsbFile psbFile = null;
 
             // Identfies filetype of the file argument,
-            // Then instantiates file with file's location and verbose or not
-            // (instantiation also leads to the creation of the decompressed
-            // *.rpx.extract file)
+            // then instantiates file with file's location and verbose or not
             if (RpxFile.IsRpx(sourcePath))
             {
                 Console.WriteLine("RPX file detected!");

--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -84,7 +84,7 @@ namespace WiiuVcExtractor
             PsbFile psbFile = null;
 
             // Identfies filetype of the file argument,
-            // then instantiates file with file's location and verbose or not
+            // then instantiates file with file's location and verbose
             if (RpxFile.IsRpx(sourcePath))
             {
                 Console.WriteLine("RPX file detected!");

--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -83,6 +83,10 @@ namespace WiiuVcExtractor
             RpxFile rpxFile = null;
             PsbFile psbFile = null;
 
+            // Identfies filetype of the file argument,
+            // Then instantiates file with file's location and verbose or not
+            // (instantiation also leads to the creation of the decompressed
+            // *.rpx.extract file)
             if (RpxFile.IsRpx(sourcePath))
             {
                 Console.WriteLine("RPX file detected!");
@@ -101,6 +105,7 @@ namespace WiiuVcExtractor
             {
                 romExtractors.Add(new NesVcExtractor(rpxFile, verbose));
                 romExtractors.Add(new SnesVcExtractor(rpxFile.DecompressedPath, verbose));
+                romExtractors.Add(new FdsVcExtractor(rpxFile, verbose));
             }
             else if (psbFile != null)
             {
@@ -111,6 +116,8 @@ namespace WiiuVcExtractor
                 romExtractors.Add(new SnesVcExtractor(sourcePath, verbose));
             }
 
+            // Check with each extractor until a valid rom is found,
+            // Then extract the rom with the appropriate extractor
             foreach (var romExtractor in romExtractors)
             {
                 if (romExtractor.IsValidRom())

--- a/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
@@ -189,6 +189,11 @@ namespace WiiuVcExtractor.RomExtractors
                                 Buffer.BlockCopy(fdsRomData, 52267, tempFdsRomData, 52235, 16);
                                 Buffer.BlockCopy(fdsRomData, 52285, tempFdsRomData, 52251, romSize - FDS_HEADER_LENGTH - 52251);
 
+                                // Corrects three incorrect bytes
+                                tempFdsRomData[8768] = 0x58;
+                                tempFdsRomData[33471] = 0x4A;
+                                tempFdsRomData[33481] = 0x4A;
+
                                 bw.Write(tempFdsRomData);
                             }
                             else

--- a/WiiuVcExtractor/RomExtractors/NesVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/NesVcExtractor.cs
@@ -38,8 +38,9 @@ namespace WiiuVcExtractor.RomExtractors
         private byte[] nesRomData;
 
         private bool verbose;
-        // Identify ROM as FDS game to prevent overwriting header
-        private bool isFDS;
+        // Identify ROM as FDS game for proper file extension and prevent
+        // corrupting header
+        private bool isFDS = false;
 
         public NesVcExtractor(RpxFile rpxFile, bool verbose = false)
         {
@@ -87,8 +88,7 @@ namespace WiiuVcExtractor.RomExtractors
                         if (!isFDS)
                         {
                             extractedRomPath = romName + ".nes";
-                        } else
-                        {
+                        } else {
                             extractedRomPath = romName + ".fds";
                         }
 
@@ -167,7 +167,8 @@ namespace WiiuVcExtractor.RomExtractors
                         {
                             byte[] buffer = br.ReadBytes(NES_HEADER_LENGTH);
 
-                            // If the buffer matches the first byte of the NES header, check the following 15 bytes
+                            // If the buffer matches the first byte of the NES 
+                            // header, check the following 15 bytes
                             if (buffer[0] == NES_HEADER_CHECK[0])
                             {
                                 Array.Copy(buffer, headerBuffer, NES_HEADER_LENGTH);
@@ -229,7 +230,6 @@ namespace WiiuVcExtractor.RomExtractors
                         }
                     }
                 }
-
             }
 
             Console.WriteLine("Not an NES or FDS VC Title");

--- a/WiiuVcExtractor/RomExtractors/NesVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/NesVcExtractor.cs
@@ -99,7 +99,7 @@ namespace WiiuVcExtractor.RomExtractors
                         int romSize = prgPageSize + chrPageSize + NES_HEADER_LENGTH;
                         Console.WriteLine("Total NES rom size: " + romSize + " Bytes");
 
-
+                        // Fix the NES header
                         Console.WriteLine("Fixing VC NES Header...");
                         nesRomHeader[BROKEN_NES_HEADER_OFFSET] = CHARACTER_BREAK;
 
@@ -125,7 +125,6 @@ namespace WiiuVcExtractor.RomExtractors
             return extractedRomPath;
         }
 
-        // Determines if this is a valid NES ROM
         public bool IsValidRom()
         {
             Console.WriteLine("Checking if this is an NES VC title...");
@@ -151,8 +150,7 @@ namespace WiiuVcExtractor.RomExtractors
                         {
                             byte[] buffer = br.ReadBytes(NES_HEADER_LENGTH);
 
-                            // If the buffer matches the first byte of the NES 
-                            // header, check the following 15 bytes
+                            // If the buffer matches the first byte of the NES header, check the following 15 bytes
                             if (buffer[0] == NES_HEADER_CHECK[0])
                             {
                                 Array.Copy(buffer, headerBuffer, NES_HEADER_LENGTH);

--- a/WiiuVcExtractor/RomExtractors/NesVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/NesVcExtractor.cs
@@ -84,7 +84,13 @@ namespace WiiuVcExtractor.RomExtractors
                         Console.WriteLine("Virtual Console Title: " + vcName);
                         Console.WriteLine("NES Title: " + romName);
 
-                        extractedRomPath = romName + ".nes";
+                        if (!isFDS)
+                        {
+                            extractedRomPath = romName + ".nes";
+                        } else
+                        {
+                            extractedRomPath = romName + ".fds";
+                        }
 
                         br.ReadBytes(VC_NAME_PADDING);
 

--- a/WiiuVcExtractor/RomExtractors/NesVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/NesVcExtractor.cs
@@ -8,12 +8,7 @@ namespace WiiuVcExtractor.RomExtractors
 {
     public class NesVcExtractor : IRomExtractor
     {
-        // Normal NES header
         private static readonly byte[] NES_HEADER_CHECK = { 0x4E, 0x45, 0x53 };
-        // Famicom Disk System header
- //       private static readonly byte[] FDS_HEADER_CHECK = { 0x01, 0x2A, 0x4E,
-  //          0x49, 0x4E, 0x54, 0x45, 0x4E, 0x44, 0x4F, 0x2D, 0x48, 0x56, 0x43,
-   //         0x2A, 0x01};
         private const int NES_HEADER_LENGTH = 16;
         private const int VC_NAME_LENGTH = 8;
         private const int VC_NAME_PADDING = 8;
@@ -38,9 +33,6 @@ namespace WiiuVcExtractor.RomExtractors
         private byte[] nesRomData;
 
         private bool verbose;
-        // Identify ROM as FDS game for proper file extension and prevent
-        // corrupting header
-//        private bool isFDS = false;
 
         public NesVcExtractor(RpxFile rpxFile, bool verbose = false)
         {
@@ -85,12 +77,7 @@ namespace WiiuVcExtractor.RomExtractors
                         Console.WriteLine("Virtual Console Title: " + vcName);
                         Console.WriteLine("NES Title: " + romName);
 
-//                        if (!isFDS)
-//                        {
-                            extractedRomPath = romName + ".nes";
-//                        } else {
-//                            extractedRomPath = romName + ".fds";
-//                        }
+                        extractedRomPath = romName + ".nes";
 
                         br.ReadBytes(VC_NAME_PADDING);
 
@@ -112,12 +99,9 @@ namespace WiiuVcExtractor.RomExtractors
                         int romSize = prgPageSize + chrPageSize + NES_HEADER_LENGTH;
                         Console.WriteLine("Total NES rom size: " + romSize + " Bytes");
 
-                        // Fix the NES header, unless rom is FDS game
-//                        if(!isFDS)
-//                        {
-                            Console.WriteLine("Fixing VC NES Header...");
-                            nesRomHeader[BROKEN_NES_HEADER_OFFSET] = CHARACTER_BREAK;
-//                        }
+
+                        Console.WriteLine("Fixing VC NES Header...");
+                        nesRomHeader[BROKEN_NES_HEADER_OFFSET] = CHARACTER_BREAK;
 
                         Console.WriteLine("Getting rom data...");
                         nesRomData = br.ReadBytes(romSize - NES_HEADER_LENGTH);
@@ -141,7 +125,7 @@ namespace WiiuVcExtractor.RomExtractors
             return extractedRomPath;
         }
 
-        // Determines if this is a valid NES ROM, with either NES or FDS header
+        // Determines if this is a valid NES ROM
         public bool IsValidRom()
         {
             Console.WriteLine("Checking if this is an NES VC title...");
@@ -198,43 +182,12 @@ namespace WiiuVcExtractor.RomExtractors
                                     }
                                 }
                             }
-
-                            /*
-                            // If the buffer fails for the normal NES header,
-                            // try again with first byte of FDS header
-                            if (buffer[0] == FDS_HEADER_CHECK[0])
-                            {
-                                Array.Copy(buffer, headerBuffer, NES_HEADER_LENGTH);
-
-                                bool headerValid = true;
-
-                                // Ensure the rest of the header is valid
-                                for (int i = 1; i < 16; i++)
-                                {
-                                    if (headerBuffer[i] != FDS_HEADER_CHECK[i])
-                                    {
-                                        headerValid = false;
-                                    }
-                                }
-
-                                if (headerValid)
-                                {
-                                    // The rom position is a header length before the current stream position
-                                    romPosition = br.BaseStream.Position - NES_HEADER_LENGTH;
-                                    vcNamePosition = romPosition - 16;
-                                    Array.Copy(headerBuffer, 0, nesRomHeader, 0, NES_HEADER_LENGTH);
-                                    Console.WriteLine("NES Rom Detected!");
-                                    isFDS = true;
-                                    return true;
-                                }
-                            }
-                            */
                         }
                     }
                 }
             }
 
-            Console.WriteLine("Not an NES or FDS VC Title");
+            Console.WriteLine("Not an NES VC Title");
 
             return false;
         }

--- a/WiiuVcExtractor/WiiuVcExtractor.csproj
+++ b/WiiuVcExtractor/WiiuVcExtractor.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DotNetZip, Version=1.13.3.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.13.3\lib\net40\DotNetZip.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -41,9 +44,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="DotNetZip">
-      <HintPath>..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileTypes\MdfHeader.cs" />

--- a/WiiuVcExtractor/WiiuVcExtractor.csproj
+++ b/WiiuVcExtractor/WiiuVcExtractor.csproj
@@ -63,6 +63,7 @@
     <Compile Include="RomExtractors\GbaVcExtractor.cs" />
     <Compile Include="RomExtractors\IRomExtractor.cs" />
     <Compile Include="Libraries\mt19937ar.cs" />
+    <Compile Include="RomExtractors\FdsVcExtractor.cs" />
     <Compile Include="RomExtractors\NesVcExtractor.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/WiiuVcExtractor/packages.config
+++ b/WiiuVcExtractor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.11.0" targetFramework="net452" />
+  <package id="DotNetZip" version="1.13.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Adds FdsVcExtractor.cs for extracting Famicom Disk System games, like Super Mario Bros The Lost Levels
  - Implements einstein95's qd2fds.py script for converting QD format FDS games to proper .fds files
    - https://gist.github.com/einstein95/6545066905680466cdf200c4cc8ca4f0
  - Corrects three incorrect bytes when extracting Lost Levels
  - Fixes issue #34
- Comments some files for clarity
- Updates Readme to include an example of FDS extraction and credits einstein95
- Updates DotNetZip to 1.13.3