### PR TITLE
Add pce support

### DIFF
--- a/WiiuVcExtractor/FileTypes/PkgContentFile.cs
+++ b/WiiuVcExtractor/FileTypes/PkgContentFile.cs
@@ -30,6 +30,9 @@ namespace WiiuVcExtractor.FileTypes
                 writePath = path;
             }
 
+            // Create the parent directory
+            Directory.CreateDirectory(Directory.GetParent(writePath).ToString());
+
             using (BinaryWriter bw = new BinaryWriter(File.Open(writePath, FileMode.Create)))
             {
                 Console.WriteLine("Writing content file {0} to {1}", path, writePath);

--- a/WiiuVcExtractor/FileTypes/PkgContentFile.cs
+++ b/WiiuVcExtractor/FileTypes/PkgContentFile.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace WiiuVcExtractor.FileTypes
+{
+    // Individual file stored within a .pkg file
+    public class PkgContentFile
+    {
+        string path;
+        byte[] content;
+
+        public string Path { get { return path; } }
+        public byte[] Content { get { return content; } }
+
+        public PkgContentFile(string path, byte[] contentBytes)
+        {
+            this.path = path;
+            this.content = contentBytes;
+        }
+
+        // Writes the content file to a given path or to a relative path if not provided
+        public void Write(string writePath = "")
+        {
+            if (String.IsNullOrEmpty(writePath))
+            {
+                writePath = path;
+            }
+
+            using (BinaryWriter bw = new BinaryWriter(File.Open(writePath, FileMode.Create)))
+            {
+                Console.WriteLine("Writing content file {0} to {1}", path, writePath);
+                bw.Write(content);
+            }
+        }
+    }
+}

--- a/WiiuVcExtractor/FileTypes/PkgFile.cs
+++ b/WiiuVcExtractor/FileTypes/PkgFile.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WiiuVcExtractor.Libraries;
+using System.IO;
+
+namespace WiiuVcExtractor.FileTypes
+{
+    // Extractor for .pkg files for PC Engine games
+    public class PkgFile
+    {
+        PkgHeader header;
+        List<PkgContentFile> contentFiles;
+        bool verbose;
+        string path;
+
+        public PkgHeader Header { get { return header; } }
+        public List<PkgContentFile> ContentFiles { get { return contentFiles; } }
+        public string Path { get { return path; } }
+
+        public static bool IsPkg(string pkgFilePath)
+        {
+            PkgHeader header = new PkgHeader(pkgFilePath);
+            return header.IsValid();
+        }
+
+        public PkgFile(string pkgFilePath, bool verbose = false)
+        {
+            Console.WriteLine("Extracting PKG file...");
+            this.verbose = verbose;
+
+            contentFiles = new List<PkgContentFile>();
+
+            path = pkgFilePath;
+
+            try
+            {
+                header = new PkgHeader(path);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Could not successfully read PKG file: " + ex.Message);
+                return;
+            }
+
+            if (verbose)
+            {
+                Console.WriteLine("Successfully read PKG file header as:\n{0}", header.ToString());
+            }
+
+            // Detect each file within the PKG file after the header and store it in memory as a PkgContentFile, start after the header
+            using (FileStream fs = new FileStream(pkgFilePath, FileMode.Open, FileAccess.Read))
+            {
+                // Skip header
+                fs.Seek(header.Length, SeekOrigin.Begin);
+                using (BinaryReader br = new BinaryReader(fs, new ASCIIEncoding()))
+                {
+                    while (br.BaseStream.Position < br.BaseStream.Length)
+                    {
+                        // Read in each section, these are arranged as a LE UINT32 describing the size followed by a null-terminated filename and its content
+                        int sectionLength = br.ReadInt32LE();
+                        string sectionPath = br.ReadNullTerminatedString();
+                        byte[] sectionContent = br.ReadBytes(sectionLength);
+                        contentFiles.Add(new PkgContentFile(sectionPath, sectionContent));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/WiiuVcExtractor/FileTypes/PkgHeader.cs
+++ b/WiiuVcExtractor/FileTypes/PkgHeader.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using WiiuVcExtractor.Libraries;
+
+namespace WiiuVcExtractor.FileTypes
+{
+    public class PkgHeader
+    {
+        private const int ENTRY_POINT_LENGTH = 0x40;
+        private const int OPTIONS_LENGTH = 0x20;
+
+        private UInt32 pkgLength;
+        private UInt32 headerContentLength;
+        private string headerFilename;
+
+        // TODO: Appears to be flags for the emulator, but unclear as to the specific purpose
+        private byte[] options;
+
+        private string entryPoint;
+        private byte[] entryPointBytes;
+
+        // TODO: Appears to be identical to the first entry point in most cases, but more data is needed
+        private string entryPoint2;
+        private byte[] entryPoint2Bytes;
+
+        // Store the total length of the file for later validation
+        private long fileLength;
+
+        public UInt32 PkgLength { get { return pkgLength; } }
+        public UInt32 Length { get { return headerContentLength + (uint)headerFilename.Length + 9; } }
+        public string Filename { get { return headerFilename; } }
+        public string EntryPoint { get { return entryPoint; } }
+        public string EntryPoint2 { get { return entryPoint2; } }
+
+        public PkgHeader(string pkgFilePath)
+        {
+            // read in the pceconfig.bin information and interpret it as the file header
+            using (FileStream fs = new FileStream(pkgFilePath, FileMode.Open, FileAccess.Read))
+            {
+                using (BinaryReader br = new BinaryReader(fs, new ASCIIEncoding()))
+                {
+                    // Read in the header (Add 4 to consider the length part of the size)
+                    pkgLength = br.ReadUInt32LE() + 4;
+
+                    // Add 4 to calculate the header length since we are considering the pkgLength to be part of it (for easier offset calculation elsewhere)
+                    headerContentLength = br.ReadUInt32LE();
+                    headerFilename = br.ReadNullTerminatedString();
+
+                    options = br.ReadBytes(OPTIONS_LENGTH);
+
+                    entryPointBytes = br.ReadBytes(ENTRY_POINT_LENGTH);
+                    entryPoint2Bytes = br.ReadBytes(ENTRY_POINT_LENGTH);
+
+                    // Parse the entry point name from each set of bytes
+                    entryPoint = entryPointBytes.ReadNullTerminatedString();
+                    entryPoint2 = entryPoint2Bytes.ReadNullTerminatedString();
+                }
+            }
+
+            fileLength = new FileInfo(pkgFilePath).Length;
+        }
+
+        public bool IsValid()
+        {
+            // Ensure the interpreted length from the header matches the actual file length
+            if (pkgLength != fileLength)
+            {
+                return false;
+            }
+
+            // Ensure the header length is non-zero
+            if (headerContentLength < 1)
+            {
+                return false;
+            }
+
+            // Ensure header filename is populated
+            if (String.IsNullOrEmpty(headerFilename))
+            {
+                return false;
+            }
+
+            // Ensure entry point is populated
+            if (String.IsNullOrEmpty(entryPoint))
+            {
+                return false;
+            }
+
+            // Ensure entry point 2 is populated
+            if (String.IsNullOrEmpty(entryPoint2))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return "PkgHeader:\n" +
+                   "pkgLength: " + pkgLength.ToString() + "\n" +
+                   "headerLength" + Length.ToString() + "\n" +
+                   "headerContentLength: " + headerContentLength.ToString() + "\n" +
+                   "headerFilename: " + headerFilename + "\n" +
+                   "entryPoint: " + entryPoint + "\n" +
+                   "entryPoint2: " + entryPoint2 + "\n";
+        }
+    }
+}

--- a/WiiuVcExtractor/Libraries/EndianUtility.cs
+++ b/WiiuVcExtractor/Libraries/EndianUtility.cs
@@ -118,5 +118,20 @@ namespace WiiuVcExtractor.Libraries
                 str = str + ch;
             return str;
         }
+
+        public static string ReadNullTerminatedString(this byte[] bytes)
+        {
+            string str = "";
+
+            using (MemoryStream ms = new MemoryStream(bytes))
+            {
+                using (BinaryReader br = new BinaryReader(ms))
+                {
+                    str = br.ReadNullTerminatedString();
+                }
+            }
+
+            return str;
+        }
     }
 }

--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -8,7 +8,7 @@ namespace WiiuVcExtractor
 {
     class Program
     {
-        private const string WIIU_VC_EXTRACTOR_VERSION = "0.6.0";
+        private const string WIIU_VC_EXTRACTOR_VERSION = "0.7.0";
 
         static void PrintUsage()
         {
@@ -29,6 +29,7 @@ namespace WiiuVcExtractor
             Console.WriteLine("wiiuvcextractor alldata.psb.m");
             Console.WriteLine("wiiuvcextractor WUP-FAME.rpx");
             Console.WriteLine("wiiuvcextractor CLV-P-SAAAE.sfrom");
+            Console.WriteLine("wiiuvcextractor pce.pkg");
             Console.WriteLine("wiiuvcextractor -v WUP-JBBE.rpx");
         }
 
@@ -82,6 +83,7 @@ namespace WiiuVcExtractor
 
             RpxFile rpxFile = null;
             PsbFile psbFile = null;
+            PkgFile pkgFile = null;
 
             // Identifies filetype of the file argument,
             // then instantiates file with file's location and verbose
@@ -94,6 +96,10 @@ namespace WiiuVcExtractor
             {
                 Console.WriteLine("PSB file detected!");
                 psbFile = new PsbFile(sourcePath);
+            }
+            else if (PkgFile.IsPkg(sourcePath))
+            {
+                pkgFile = new PkgFile(sourcePath, verbose);
             }
 
             // Create the list of rom extractors
@@ -108,6 +114,10 @@ namespace WiiuVcExtractor
             else if (psbFile != null)
             {
                 romExtractors.Add(new GbaVcExtractor(psbFile, verbose));
+            }
+            else if (pkgFile != null)
+            {
+                romExtractors.Add(new PceVcExtractor(pkgFile, verbose));
             }
             else if (Path.GetExtension(sourcePath) == ".sfrom")
             {

--- a/WiiuVcExtractor/RomExtractors/PceVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/PceVcExtractor.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Text;
+using System.IO;
+using WiiuVcExtractor.FileTypes;
+using WiiuVcExtractor.Libraries;
+
+namespace WiiuVcExtractor.RomExtractors
+{
+    public class PceVcExtractor : IRomExtractor
+    {
+        private const int PCE_HEADER_LENGTH = 16;
+
+        private PkgFile pkgFile;
+
+        private bool verbose;
+
+        public PceVcExtractor(PkgFile pkgFile, bool verbose = false)
+        {
+            this.verbose = verbose;
+            this.pkgFile = pkgFile;
+        }
+
+        public string ExtractRom()
+        {
+            // Find any PCE files within the pkg file and write them to complete extraction
+            PkgContentFile pceFile = pkgFile.ContentFiles.Find(x => Path.GetExtension(x.Path).ToLower() == ".pce");
+            if (pceFile != null)
+            {
+                pceFile.Write();
+                return pceFile.Path;
+            }
+
+            // If no PCE files exist, attempt to find and process an HCD file and recombine all content files into a usable format
+
+            return "";
+        }
+
+        public bool IsValidRom()
+        {
+            Console.WriteLine("Checking if this is a PC Engine VC title...");
+
+            string entryPointExtension = Path.GetExtension(pkgFile.Header.EntryPoint.ToLower());
+            // Check whether the entry point is a .pce or .hcd file (case-insensitive)
+
+            if (entryPointExtension == ".pce" || entryPointExtension == ".hcd")
+            {
+                Console.WriteLine("PC Engine VC Rom detected! Extension {0} was found in the {1} entry point.", entryPointExtension, pkgFile.Path);
+                return true;
+            }
+
+            Console.WriteLine("Not a PC Engine VC Title");
+            return false;
+        }
+    }
+}

--- a/WiiuVcExtractor/RomExtractors/PceVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/PceVcExtractor.cs
@@ -22,15 +22,49 @@ namespace WiiuVcExtractor.RomExtractors
 
         public string ExtractRom()
         {
+            if (verbose)
+            {
+                Console.WriteLine("Extracting rom from PKG file...");
+                Console.WriteLine("Determining type of rom within PKG file (.pce or CD)");
+            }
+
             // Find any PCE files within the pkg file and write them to complete extraction
             PkgContentFile pceFile = pkgFile.ContentFiles.Find(x => Path.GetExtension(x.Path).ToLower() == ".pce");
             if (pceFile != null)
             {
+                if (verbose)
+                {
+                    Console.WriteLine(".pce file found!");
+                }
+
                 pceFile.Write();
                 return pceFile.Path;
             }
 
             // If no PCE files exist, attempt to find and process an HCD file and recombine all content files into a usable format
+            PkgContentFile hcdFile = pkgFile.ContentFiles.Find(x => Path.GetExtension(x.Path).ToLower() == ".hcd");
+            if (hcdFile != null)
+            {
+                if (verbose)
+                {
+                    Console.WriteLine(".hcd file found!");
+                }
+
+                // .hcd file was found, create files for all content files
+                foreach (var contentFile in pkgFile.ContentFiles)
+                {
+                    if (verbose)
+                    {
+                        Console.WriteLine("Extracting {0}...", contentFile.Path);
+                    }
+                    contentFile.Write();
+                }
+
+                // TODO: Generate a .cue file for everything
+
+                return hcdFile.Path;
+            }
+
 
             return "";
         }

--- a/WiiuVcExtractor/WiiuVcExtractor.csproj
+++ b/WiiuVcExtractor/WiiuVcExtractor.csproj
@@ -48,6 +48,9 @@
   <ItemGroup>
     <Compile Include="FileTypes\MdfHeader.cs" />
     <Compile Include="FileTypes\MdfPsbFile.cs" />
+    <Compile Include="FileTypes\PkgContentFile.cs" />
+    <Compile Include="FileTypes\PkgFile.cs" />
+    <Compile Include="FileTypes\PkgHeader.cs" />
     <Compile Include="FileTypes\PsbChunkTable.cs" />
     <Compile Include="FileTypes\PsbEntryTable.cs" />
     <Compile Include="FileTypes\PsbFile.cs" />
@@ -67,6 +70,7 @@
     <Compile Include="RomExtractors\NesVcExtractor.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RomExtractors\PceVcExtractor.cs" />
     <Compile Include="RomExtractors\SnesVcExtractor.cs" />
     <Compile Include="FileTypes\RpxFile.cs" />
     <Compile Include="FileTypes\RpxHeader.cs" />
@@ -83,6 +87,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="snesromsizes.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="pceromnames.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <None Include="packages.config" />

--- a/WiiuVcExtractor/pceromnames.csv
+++ b/WiiuVcExtractor/pceromnames.csv
@@ -1,0 +1,120 @@
+WUP-PNFP,Air Zonk
+WUP-PNLP,Alien Crush
+WUP-PPGP,Battle Chopper
+WUP-PPSP,Battle Lode Runner
+WUP-PNKP,Blazing Lazers
+WUP-PPTP,Bomberman 93
+WUP-PNWP,Bomberman 94
+WUP-PN7P,Bomberman Panic Bomber
+WUP-PNHP,Bonk 3 Bonks Big Adventure
+WUP-PNBP,Bonks Adventure
+WUP-PNGP,Bonks Revenge
+WUP-PNZP,Break In
+WUP-PNPP,Chew Man Fu
+WUP-PNJP,China Warrior
+WUP-PNXP,Detana Twin Bee
+WUP-PN6P,Devils Crush
+WUP-PNYP,Digital Champ
+WUP-PNSP,Double Dungeons
+WUP-PN3P,Dungeon Explorer
+WUP-PNQP,Final Soldier
+WUP-PNAP,Gradius
+WUP-PPEP,ImageFight
+WUP-PPFP,ImageFight II
+WUP-PPCP,Legend of Hero Tonma
+WUP-PN5P,Lords of Thunder
+WUP-PN2P,Motoroader
+WUP-PPUP,Necromancer
+WUP-PNEP,Neutopia
+WUP-PNMP,Neutopia II
+WUP-PNCP,New Adventure Island
+WUP-PPDP,Ninja Spirit
+WUP-PNUP,Power Golf
+WUP-PPAP,R-Type
+WUP-PNVP,Salamander
+WUP-PNNP,Shockman
+WUP-PNTP,Soldier Blade
+WUP-PNDP,Super Star Soldier
+WUP-PNRP,Victory Run
+WUP-PPBP,Vigilante
+WUP-PN4P,World Sports Competition
+WUP-PNFE,Air Zonk
+WUP-PNLE,Alien Crush
+WUP-PPGE,Battle Chopper
+WUP-PPSE,Battle Lode Runner
+WUP-PNKE,Blazing Lazers
+WUP-PPTE,Bomberman 93
+WUP-PNWE,Bomberman 94
+WUP-PN7E,Bomberman Panic Bomber
+WUP-PNHE,Bonk 3 Bonks Big Adventure
+WUP-PNBE,Bonks Adventure
+WUP-PNGE,Bonks Revenge
+WUP-PNZE,Break In
+WUP-PNPE,Chew Man Fu
+WUP-PNJE,China Warrior
+WUP-PNXE,Detana Twin Bee
+WUP-PN6E,Devils Crush
+WUP-PNYE,Digital Champ
+WUP-PNSE,Double Dungeons
+WUP-PN3E,Dungeon Explorer
+WUP-PNQE,Final Soldier
+WUP-PNAE,Gradius
+WUP-PPEE,ImageFight
+WUP-PPFE,ImageFight II
+WUP-PPCE,Legend of Hero Tonma
+WUP-PN5E,Lords of Thunder
+WUP-PN2E,Motoroader
+WUP-PPUE,Necromancer
+WUP-PNEE,Neutopia
+WUP-PNME,Neutopia II
+WUP-PNCE,New Adventure Island
+WUP-PPDE,Ninja Spirit
+WUP-PNUE,Power Golf
+WUP-PPAE,R-Type
+WUP-PNVE,Salamander
+WUP-PNNE,Shockman
+WUP-PNTE,Soldier Blade
+WUP-PNDE,Super Star Soldier
+WUP-PNRE,Victory Run
+WUP-PPBE,Vigilante
+WUP-PN4E,World Sports Competition
+WUP-PNFJ,Air Zonk
+WUP-PNLJ,Alien Crush
+WUP-PPGJ,Battle Chopper
+WUP-PPSJ,Battle Lode Runner
+WUP-PNKJ,Blazing Lazers
+WUP-PPTJ,Bomberman 93
+WUP-PNWJ,Bomberman 94
+WUP-PN7J,Bomberman Panic Bomber
+WUP-PNHJ,Bonk 3 Bonks Big Adventure
+WUP-PNBJ,Bonks Adventure
+WUP-PNGJ,Bonks Revenge
+WUP-PNZJ,Break In
+WUP-PNPJ,Chew Man Fu
+WUP-PNJJ,China Warrior
+WUP-PNXJ,Detana Twin Bee
+WUP-PN6J,Devils Crush
+WUP-PNYJ,Digital Champ
+WUP-PNSJ,Double Dungeons
+WUP-PN3J,Dungeon Explorer
+WUP-PNQJ,Final Soldier
+WUP-PNAJ,Gradius
+WUP-PPEJ,ImageFight
+WUP-PPFJ,ImageFight II
+WUP-PPCJ,Legend of Hero Tonma
+WUP-PN5J,Lords of Thunder
+WUP-PN2J,Motoroader
+WUP-PPUJ,Necromancer
+WUP-PNEJ,Neutopia
+WUP-PNMJ,Neutopia II
+WUP-PNCJ,New Adventure Island
+WUP-PPDJ,Ninja Spirit
+WUP-PNUJ,Power Golf
+WUP-PPAJ,R-Type
+WUP-PNVJ,Salamander
+WUP-PNNJ,Shockman
+WUP-PNTJ,Soldier Blade
+WUP-PNDJ,Super Star Soldier
+WUP-PNRJ,Victory Run
+WUP-PPBJ,Vigilante
+WUP-PN4J,World Sports Competition


### PR DESCRIPTION
This change adds PC engine support to the virtual console extractor.

This also include PC engine CD support, but it does not extract it into a format that can be used immediately. This will require further research and development.