### PR TITLE
Multi-Disk Famicom Disk System Extraction

### DIFF
--- a/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
@@ -122,13 +122,13 @@ namespace WiiuVcExtractor.RomExtractors
                                     // Read in 2nd disk header
                                     byte[] headerBuffer = brDskChk.ReadBytes(FDS_HEADER_LENGTH);
 
-                                    // Iterate through buffer
+                                    // Iterate through buffer and header
                                     for (int i = 0; i < FDS_HEADER_CHECK.Length && headerValid; i++)
                                     {
                                         // Compare byte at buffer position to corresponding byte in header
                                         if (headerBuffer[i] != FDS_HEADER_CHECK[i])
                                         {
-                                            // If they don't match, header is wrong
+                                            // If they don't match, header is wrong - end loops
                                             headerValid = false;
                                         }
                                     }

--- a/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
@@ -36,8 +36,6 @@ namespace WiiuVcExtractor.RomExtractors
 
         private bool verbose;
 
-        private bool isLL = false;
-
         public FdsVcExtractor(RpxFile rpxFile, bool verbose = false)
         {
             this.verbose = verbose;
@@ -81,12 +79,6 @@ namespace WiiuVcExtractor.RomExtractors
                             Console.WriteLine("Could not determine rom name, " +
                                 "please enter your desired filename:");
                             romName = Console.ReadLine();
-                        }
-
-                        // Patch for Lost Levels - 3 incorrect bytes?
-                        if(vcName.Equals("WUP-FA9E"))
-                        {
-                           isLL = true;
                         }
 
                         Console.WriteLine("Virtual Console Title: " + vcName);
@@ -219,15 +211,6 @@ namespace WiiuVcExtractor.RomExtractors
 
                                 // Copy current disk data to the full FDS game data array at the correct position for the disk
                                 Buffer.BlockCopy(currentDisk, 0, fullGameDataFDS, disk * fdsDiskSize, fdsDiskSize);
-                            }
-
-                            // if Lost Levels, correct three bytes
-                            // why is this happening? these three are the only things preventing the checksum from matching no-intro 
-                            if (isLL)
-                            {
-                                fullGameDataFDS[8784] = 0x58;
-                                fullGameDataFDS[33487] = 0x4A;
-                                fullGameDataFDS[33497] = 0x4A;
                             }
 
                             Console.WriteLine("Total FDS rom size: " + fullGameDataFDS.Length + " Bytes");

--- a/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
@@ -147,12 +147,6 @@ namespace WiiuVcExtractor.RomExtractors
                         fullGameDataFDS = new byte[fdsDiskSize * numberOfDisks];
 
                         Console.WriteLine("Number of Disks: " + numberOfDisks);
-
-                        //
-                        // MOVE THIS TO AFTER FDS CONVERSION
-                        //
-                        //Console.WriteLine("Total FDS rom size: " + qdDiskSize * numberOfDisks + " Bytes");
-
                         Console.WriteLine("Getting rom data...");
 
                         // From the position at the end of the header, read the rest of the rom
@@ -235,6 +229,8 @@ namespace WiiuVcExtractor.RomExtractors
                                 fullGameDataFDS[33487] = 0x4A;
                                 fullGameDataFDS[33497] = 0x4A;
                             }
+
+                            Console.WriteLine("Total FDS rom size: " + fullGameDataFDS.Length + " Bytes");
 
                             Console.WriteLine("Writing rom data...");
                             bw.Write(fullGameDataFDS);

--- a/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/FdsVcExtractor.cs
@@ -103,10 +103,10 @@ namespace WiiuVcExtractor.RomExtractors
                         {
                             using (BinaryReader brDskChk = new BinaryReader(fsDskChk, new ASCIIEncoding()))
                             {
-                                // Bool to account for proper header
+                                // Bool to account for correct header
                                 bool headerValid = true;
 
-                                // First side is known to exist, so seek ahead to next disk
+                                // First side is known to exist, so seek ahead to next side
                                 brDskChk.BaseStream.Seek(vcNamePosition, SeekOrigin.Begin);
                                 brDskChk.ReadBytes(VC_NAME_LENGTH);
                                 brDskChk.ReadBytes(VC_NAME_PADDING);


### PR DESCRIPTION
- Fixes https://github.com/wheatevo/wiiu-vc-extractor/issues/47
- Now supports double-sided FDS titles like Bubble Bobble, as well as multi-disk titles like Shin Onigashima
- Removed patch for Super Mario Bros 2 Lost Levels, as VC ROMs are often pre-patched