### PR TITLE
Add SNES S-DD1 extraction support

### DIFF
--- a/WiiuVcExtractor/Libraries/Sdd1/BitplanesExtractor.cs
+++ b/WiiuVcExtractor/Libraries/Sdd1/BitplanesExtractor.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WiiuVcExtractor.Libraries.Sdd1
+{
+    class BitplanesExtractor
+    {
+        private const byte HEADER_MASK = 0x0C;
+        private byte bitplanesInfo;
+        private UInt16 inputLength;
+        private byte[] inputBuffer;
+        private byte inBitInd;
+        private byte currBitplane;
+        private List<byte>[] bitplaneBuffer;
+        private byte[] bpBitInd;
+        
+        public BitplanesExtractor(ref List<byte>[] bpBuffer)
+        {
+            bpBitInd = new byte[8];
+            bitplaneBuffer = bpBuffer;
+        }
+
+        public void PrepareComp(byte[] inBuffer, byte header)
+        {
+            inputLength = (UInt16)inBuffer.Length;
+            inputBuffer = inBuffer;
+            bitplanesInfo = (byte)(header & HEADER_MASK);
+        }
+
+        public void Launch()
+        {
+            --inputLength;
+            switch (bitplanesInfo)
+            {
+                case 0x00:
+                    currBitplane = 1;
+                    break;
+                case 0x04:
+                    currBitplane = 7;
+                    break;
+                case 0x08:
+                    currBitplane = 3;
+                    break;
+                case 0x0c:
+                    inBitInd = 7;
+                    for (byte i = 0; i < 8; i++)
+                    {
+                        bpBitInd[i] = 0;
+                    }
+                    break;
+            }
+
+            UInt16 counter = 0;
+
+            do
+            {
+                switch (bitplanesInfo)
+                {
+                    case 0x00:
+                        currBitplane ^= 0x01;
+                        bitplaneBuffer[currBitplane].Add(inputBuffer[counter]);
+                        break;
+                    case 0x04:
+                        currBitplane ^= 0x01;
+                        if ((counter & 0x000f) == 0)
+                        {
+                            currBitplane = ((byte)((currBitplane + 2) & 0x07));
+                        }
+                        bitplaneBuffer[currBitplane].Add(inputBuffer[counter]);
+                        break;
+                    case 0x08:
+                        currBitplane ^= 0x01;
+                        if ((counter & 0x000f) == 0)
+                        {
+                            currBitplane ^= 0x02;
+                        }
+                        bitplaneBuffer[currBitplane].Add(inputBuffer[counter]);
+                        break;
+                    case 0x0c:
+                        for (byte i = 0; i < 8; i++) PutBit(i, counter);
+                        break;
+                }
+            } while (counter++ < inputLength);
+        }
+
+        private void PutBit(byte bitplane, UInt16 counter)
+        {
+            List<byte> currBPBuf = bitplaneBuffer[bitplane];
+            byte currBitInd = bpBitInd[bitplane];
+
+            if (currBitInd == 0)
+            {
+                currBPBuf.Add(0);
+            }
+
+            currBPBuf[currBPBuf.Count() - 1] |= (byte)((((inputBuffer[counter]) & (0x80 >> inBitInd)) << inBitInd) >> currBitInd);
+
+            currBitInd++;
+            currBitInd &= 0x07;
+
+            bpBitInd[bitplane] = currBitInd;
+            inBitInd--;
+            inBitInd &= 0x07;
+        }
+    }
+}

--- a/WiiuVcExtractor/Libraries/Sdd1/Compressor.cs
+++ b/WiiuVcExtractor/Libraries/Sdd1/Compressor.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WiiuVcExtractor.Libraries.Sdd1
+{
+    class Compressor
+    {
+        private List<byte>[] bitplaneBuffer;
+        private List<byte> codewordsSequence;
+        private List<byte>[] codewordBuffer;
+        private BitplanesExtractor be;
+        private ContextModel cm;
+        private GolombCodeEncoder gce;
+        private ProbabilityEstimationModule pem;
+        private Interleaver interleaver;
+        public Compressor()
+        {
+            codewordsSequence = new List<byte>();
+            codewordBuffer = new List<byte>[8];
+            bitplaneBuffer = new List<byte>[8];
+            for (int i = 0; i < 8; i++)
+            {
+                bitplaneBuffer[i] = new List<byte>();
+                codewordBuffer[i] = new List<byte>();
+            }
+
+            be = new BitplanesExtractor(ref bitplaneBuffer);
+            cm = new ContextModel(ref bitplaneBuffer);
+            gce = new GolombCodeEncoder(ref codewordsSequence, ref codewordBuffer);
+            pem = new ProbabilityEstimationModule(ref cm, ref gce);
+            interleaver = new Interleaver(ref codewordsSequence, ref codewordBuffer);
+        }
+
+        public byte[] Compress(byte[] inBuf, out UInt32 outLen, byte[] outBuf)
+        {
+            UInt32 minLength;
+            byte[] buffer;
+
+            outBuf = Compress(0, inBuf, out outLen, outBuf);
+
+            minLength = outLen;
+            buffer = new byte[outLen];
+            for (UInt32 i = 0; i < outLen; i++)
+            {
+                buffer[i] = outBuf[i];
+            }
+
+            for (byte j=1; j < 16; j++)
+            {
+                outBuf = Compress(j, inBuf, out outLen, outBuf);
+                if (outLen < minLength)
+                {
+                    minLength = outLen;
+                    for (UInt32 i = 0; i < outLen; i++)
+                    {
+                        buffer[i] = outBuf[i];
+                    }
+                }
+            }
+
+            if (minLength < outLen)
+            {
+                outLen = minLength;
+                for (UInt32 i = 0; i < minLength; i++)
+                {
+                    outBuf[i] = buffer[i];
+                }
+            }
+
+            return outBuf;
+        }
+
+        public byte[] Compress(byte header, byte[] inBuf, out UInt32 outLen, byte[] outBuf)
+        {
+            // Step 1
+            for (byte i = 0; i < 8; i++)
+            {
+                bitplaneBuffer[i].Clear();
+            }
+            be.PrepareComp(inBuf, header);
+            be.Launch();
+
+            // Step 2
+            codewordsSequence.Clear();
+            for (byte i = 0; i < 8; i++)
+            {
+                codewordBuffer[i].Clear();
+            }
+            cm.PrepareComp(header);
+            pem.PrepareComp(header, (UInt16)inBuf.Length);
+            gce.PrepareComp();
+            pem.Launch();
+
+            // Step 3
+            interleaver.PrepareComp(header, outBuf);
+            outBuf = interleaver.Launch(out outLen);
+
+            return outBuf;
+        }
+    }
+}

--- a/WiiuVcExtractor/Libraries/Sdd1/ContextModel.cs
+++ b/WiiuVcExtractor/Libraries/Sdd1/ContextModel.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WiiuVcExtractor.Libraries.Sdd1
+{
+    class ContextModel
+    {
+        private byte bitplanesInfo;
+        private byte contextBitsInfo;
+        private List<byte>[] bitplaneBuffer;
+        private byte[] bpBitInd;
+        private byte bitNumber;
+        private int[] byteIndex;
+        private byte currBitplane;
+        private UInt16[] prevBitplaneBits;
+        public ProbabilityEstimationModule pem;
+
+        public ContextModel(ref List<byte>[] bpBuffer)
+        {
+            prevBitplaneBits = new UInt16[8];
+            bpBitInd = new byte[8];
+            byteIndex = new int[8];
+            bitplaneBuffer = bpBuffer;
+        }
+
+        public void PrepareComp(byte header)
+        {
+            bitplanesInfo = (byte)(header & 0x0c);
+            contextBitsInfo = (byte)(header & 0x03);
+            for (int i = 0; i < 8; i++)
+            {
+                byteIndex[i] = 0;
+                bpBitInd[i] = 0;
+                prevBitplaneBits[i] = 0;
+            }
+            bitNumber = 0;
+            switch (bitplanesInfo)
+            {
+                case 0x00:
+                    currBitplane = 1;
+                    break;
+                case 0x04:
+                    currBitplane = 7;
+                    break;
+                case 0x08:
+                    currBitplane = 3;
+                    break;
+            }
+        }
+
+        // returns array with [bit, context]
+        public byte[] GetBit()
+        {
+            byte bit;
+            byte currContext;
+
+            switch (bitplanesInfo)
+            {
+                case 0x00:
+                    currBitplane ^= 0x01;
+                    break;
+                case 0x04:
+                    currBitplane ^= 0x01;
+                    if ((bitNumber & 0x7f) == 0)
+                    {
+                        currBitplane = (byte)((currBitplane + 2) & 0x07);
+                    }
+                    break;
+                case 0x08:
+                    currBitplane ^= 0x01;
+                    if ((bitNumber & 0x7f) == 0)
+                    {
+                        currBitplane ^= 0x02; 
+                    }
+                    break;
+                case 0x0c:
+                    currBitplane = (byte)(bitNumber & 0x07);
+                    break;
+            }
+
+            // Use this where context_bits is used
+            // prevBitplaneBits[currBitplane]
+
+            currContext = (byte)((currBitplane & 0x01) << 4);
+
+            switch (contextBitsInfo)
+            {
+                case 0x00:
+                    currContext |= (byte)(((prevBitplaneBits[currBitplane] & 0x01c0) >> 5) | (prevBitplaneBits[currBitplane] & 0x0001));
+                    break;
+                case 0x01:
+                    currContext |= (byte)(((prevBitplaneBits[currBitplane] & 0x0180) >> 5) | (prevBitplaneBits[currBitplane] & 0x0001));
+                    break;
+                case 0x02:
+                    currContext |= (byte)(((prevBitplaneBits[currBitplane] & 0x00c0) >> 5) | (prevBitplaneBits[currBitplane] & 0x0001));
+                    break;
+                case 0x03:
+                    currContext |= (byte)(((prevBitplaneBits[currBitplane] & 0x0180) >> 5) | (prevBitplaneBits[currBitplane] & 0x0003));
+                    break;
+            }
+
+            if (byteIndex[currBitplane] == bitplaneBuffer[currBitplane].Count)
+            {
+                bit = pem.GetMPS(currContext);
+            }
+            else
+            {
+                bit = 0;
+
+                if (((bitplaneBuffer[currBitplane][byteIndex[currBitplane]]) & (0x80 >> bpBitInd[currBitplane])) != 0)
+                {
+                    bit = 1;
+                }
+
+                if (((++bpBitInd[currBitplane]) & 0x08) != 0)
+                {
+                    bpBitInd[currBitplane] = 0;
+                    byteIndex[currBitplane]++;
+                }
+            }
+
+            prevBitplaneBits[currBitplane] <<= 1;
+            prevBitplaneBits[currBitplane] |= bit;
+
+            bitNumber++;
+
+            byte[] returnArray = new byte[2];
+            returnArray[0] = bit;
+            returnArray[1] = currContext;
+
+            return returnArray;
+        }
+    }
+}

--- a/WiiuVcExtractor/Libraries/Sdd1/GolombCodeEncoder.cs
+++ b/WiiuVcExtractor/Libraries/Sdd1/GolombCodeEncoder.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WiiuVcExtractor.Libraries.Sdd1
+{
+    class GolombCodeEncoder
+    {
+        private List<byte> codewSequence;
+        private List<byte>[] codewBuffer;
+        byte[] bitInd;
+        byte[] MPScount;
+
+        public GolombCodeEncoder(ref List<byte> associatedCWSeq, ref List<byte>[] cwBuf)
+        {
+            codewSequence = associatedCWSeq;
+            codewBuffer = cwBuf;
+            bitInd = new byte[8];
+            MPScount = new byte[8];
+        }
+
+        public void PrepareComp()
+        {
+            for (byte i = 0; i < 8; i++)
+            {
+                MPScount[i] = 0;
+                bitInd[i] = 0;
+            }
+        }
+
+        public byte PutBit(byte codeNum, byte bit, byte endOfRun)
+        {
+            byte rMPScount = MPScount[codeNum];
+
+            if (MPScount[codeNum] == 0)
+            {
+                codewSequence.Add(codeNum);
+            }
+
+            if (bit != 0)
+            {
+                endOfRun = 1;
+                OutputBit(codeNum, 1);
+                for (byte i = 0, aux = 0x01; i < codeNum; i++, aux<<=1)
+                {
+                    byte auxOutputBit = 0;
+                    if ((MPScount[codeNum] & aux) == 0)
+                    {
+                        auxOutputBit = 1;
+                    }
+
+                    OutputBit(codeNum, auxOutputBit);
+                }
+                MPScount[codeNum] = 0;
+            } 
+            else
+            { 
+                if (++(MPScount[codeNum]) == (1<<codeNum))
+                {
+                    endOfRun = 1;
+                    OutputBit(codeNum, 0);
+                    MPScount[codeNum] = 0;
+                }
+                else
+                {
+                    endOfRun = 0;
+                }
+            }
+
+            return endOfRun;
+        }
+
+        public void FinishComp()
+        {
+            for (byte i = 0; i < 8; i++)
+            {
+                if (MPScount[i] != 0)
+                {
+                    OutputBit(i, 0);
+                }
+            }
+        }
+
+        public void OutputBit(byte codeNum, byte bit)
+        {
+            byte rBitInd = bitInd[codeNum];
+            List<byte> rCodewBuffer = codewBuffer[codeNum];
+            byte oBit = 0;
+                
+            if (bit != 0)
+            {
+                oBit = (byte)(0x80 >> bitInd[codeNum]);
+            }
+
+            if (bitInd[codeNum] == 0)
+            {
+                codewBuffer[codeNum].Add(0);
+            }
+
+            codewBuffer[codeNum][codewBuffer[codeNum].Count - 1] |= oBit;
+
+            ++bitInd[codeNum];
+            bitInd[codeNum] &= 0x07;
+        }
+    }
+}

--- a/WiiuVcExtractor/Libraries/Sdd1/Interleaver.cs
+++ b/WiiuVcExtractor/Libraries/Sdd1/Interleaver.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WiiuVcExtractor.Libraries.Sdd1
+{
+    class Interleaver
+    {
+        private List<byte> codewSequence;
+        private List<byte>[] codewBuffer;
+        byte[] bitInd;
+        private int[] byteIndex;
+        UInt32 outputLength;
+        byte[] outputBuffer;
+        UInt32 outputBufferIndex;
+        byte oBitInd;
+
+        public Interleaver(ref List<byte> associatedCWSeq, ref List<byte>[] cwBuf)
+        {
+            codewSequence = associatedCWSeq;
+            codewBuffer = cwBuf;
+            bitInd = new byte[8];
+            byteIndex = new int[8];
+        }
+
+        public void PrepareComp(byte header, byte[] outBuf)
+        {
+            outputLength = 0;
+            outputBufferIndex = 0;
+            outputBuffer = outBuf;
+            outputBuffer[outputBufferIndex] = (byte)(header << 4);
+            oBitInd = 4;
+            for (byte i = 0; i < 8; i++)
+            {
+                byteIndex[i] = 0;
+                bitInd[i] = 0;
+            }
+        }
+
+        public byte[] Launch(out UInt32 outLen)
+        {
+            for (int i = 0; i < codewSequence.Count; i++)
+            {
+                if (MoveBit(codewSequence[i]) != 0)
+                {
+                    for (byte j = 0; j < codewSequence[i]; j++)
+                    {
+                        MoveBit(codewSequence[i]);
+                    }
+                }
+            }
+
+            if (oBitInd != 0)
+            {
+                ++outputLength;
+            }
+
+            outLen = outputLength;
+
+            return outputBuffer;
+        }
+
+        private byte MoveBit(byte codeNum)
+        {
+            if (oBitInd == 0)
+            {
+                outputBuffer[outputBufferIndex] = 0;
+            }
+
+            byte bit = (byte)((codewBuffer[codeNum][byteIndex[codeNum]] & (0x80 >> bitInd[codeNum])) << bitInd[codeNum]);
+            outputBuffer[outputBufferIndex] |= (byte)(bit >> oBitInd);
+
+            if ((++bitInd[codeNum] & 0x08) != 0)
+            {
+                bitInd[codeNum] = 0;
+                byteIndex[codeNum]++;
+            }
+
+            if ((++oBitInd & 0x08) != 0)
+            {
+                oBitInd = 0;
+                outputBufferIndex++;
+                ++outputLength;
+            }
+
+            return bit;
+        }
+    }
+}

--- a/WiiuVcExtractor/Libraries/Sdd1/ProbabilityEstimationModule.cs
+++ b/WiiuVcExtractor/Libraries/Sdd1/ProbabilityEstimationModule.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WiiuVcExtractor.Libraries.Sdd1
+{
+    class ProbabilityEstimationModule
+    {
+        private ContextModel cm;
+        private GolombCodeEncoder gce;
+        UInt32 inputLength;
+        private struct State
+        {
+            public byte codeNum;
+            public byte nextIfMPS;
+            public byte nextIfLPS;
+
+            public State(byte code, byte mps, byte lps)
+            {
+                codeNum = code;
+                nextIfMPS = mps;
+                nextIfLPS = lps;
+            }
+        }
+
+        private struct SDD1ContextInfo
+        {
+            public byte status;
+            public byte MPS;
+            public SDD1ContextInfo(byte stat, byte mps)
+            {
+                status = stat;
+                MPS = mps;
+            }
+        }
+
+        State[] stateEvolutionTable;
+        SDD1ContextInfo[] contextInfo;
+
+        public ProbabilityEstimationModule(ref ContextModel associatedCM, ref GolombCodeEncoder associatedGCE)
+        {
+            cm = associatedCM;
+            cm.pem = this;
+            gce = associatedGCE;
+            contextInfo = new SDD1ContextInfo[32];
+
+            stateEvolutionTable = new State[]
+            {
+                new State(0,25,25),
+                new State(0, 2, 1),
+                new State(0, 3, 1),
+                new State(0, 4, 2),
+                new State(0, 5, 3),
+                new State(1, 6, 4),
+                new State(1, 7, 5),
+                new State(1, 8, 6),
+                new State(1, 9, 7),
+                new State(2,10, 8),
+                new State(2,11, 9),
+                new State(2,12,10),
+                new State(2,13,11),
+                new State(3,14,12),
+                new State(3,15,13),
+                new State(3,16,14),
+                new State(3,17,15),
+                new State(4,18,16),
+                new State(4,19,17),
+                new State(5,20,18),
+                new State(5,21,19),
+                new State(6,22,20),
+                new State(6,23,21),
+                new State(7,24,22),
+                new State(7,24,23),
+                new State(0,26, 1),
+                new State(1,27, 2),
+                new State(2,28, 4),
+                new State(3,29, 8),
+                new State(4,30,12),
+                new State(5,31,16),
+                new State(6,32,18),
+                new State(7,24,22)
+            };
+        }
+
+        public void PrepareComp(byte header, UInt16 length)
+        {
+            for (byte i = 0; i < 32; i++)
+            {
+                contextInfo[i].status = 0;
+                contextInfo[i].MPS = 0;
+            }
+            inputLength = length;
+            if (((header & 0x0c) != 0x0c) && ((length & 0x0001) != 0))
+            {
+                inputLength++;
+            }
+            inputLength <<= 3;
+        }
+
+        public byte GetMPS(byte context)
+        {
+            return contextInfo[context].MPS;
+        }
+
+        public void Launch()
+        {
+            byte bit;
+            byte context;
+            byte currStatus;
+            byte endOfRun = 0;
+            State currState;
+            byte[] bitReturnBuffer = new byte[2];
+
+            for (UInt32 i = 0; i < inputLength; i++)
+            {
+                bitReturnBuffer = cm.GetBit();
+                bit = bitReturnBuffer[0];
+                context = bitReturnBuffer[1];
+                currStatus = contextInfo[context].status;
+                currState = stateEvolutionTable[currStatus];
+                bit ^= contextInfo[context].MPS;
+                endOfRun = gce.PutBit(currState.codeNum, bit, endOfRun);
+                if (endOfRun != 0)
+                {
+                    if (bit != 0)
+                    {
+                        if ((currStatus & 0xfe) == 0)
+                        {
+                            contextInfo[context].MPS ^= 0x01;
+                        } 
+                        contextInfo[context].status = currState.nextIfLPS;
+                    }
+                    else
+                    {
+                        contextInfo[context].status = currState.nextIfMPS;
+                    }
+                }
+            }
+
+            gce.FinishComp();
+        }
+    }
+}

--- a/WiiuVcExtractor/Libraries/Sdd1/Sdd1Pointer.cs
+++ b/WiiuVcExtractor/Libraries/Sdd1/Sdd1Pointer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WiiuVcExtractor.Libraries.Sdd1
+{
+    public class Sdd1Pointer
+    {
+        public long pointerLocation;
+        public long dataLocation;
+        public long dataLength;
+
+        public Sdd1Pointer(long ptrLocation, long datLocation)
+        {
+            pointerLocation = ptrLocation;
+            dataLocation = datLocation;
+            dataLength = 0;
+        }
+    }
+}

--- a/WiiuVcExtractor/Libraries/SnesSdd1Extractor.cs
+++ b/WiiuVcExtractor/Libraries/SnesSdd1Extractor.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using WiiuVcExtractor.Libraries.Sdd1;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace WiiuVcExtractor.Libraries
+{
+    public class SnesSdd1Extractor
+    {
+        private static readonly byte[] SDD1_SIGNATURE = { 0x53, 0x44, 0x44, 0x31 }; // SDD1 ASCII
+        private byte[] romData;
+        private byte[] rawSdd1Data;
+        private long sdd1DataOffset;
+        private List<Sdd1Pointer> sdd1Pointers;
+
+        public SnesSdd1Extractor(byte[] snesRomData, byte[] rawSdd1Data, long sdd1DataOffset)
+        {
+            this.sdd1DataOffset = sdd1DataOffset;
+            this.romData = snesRomData;
+            this.rawSdd1Data = rawSdd1Data;
+            sdd1Pointers = new List<Sdd1Pointer>();
+        }
+
+        public byte[] ExtractSdd1Data()
+        {
+            Console.WriteLine("Extracting S-DD1 Data...");
+
+            Console.WriteLine("Appended rom data size: {0}", rawSdd1Data.Length);
+
+            byte[] processedRom = new byte[romData.Length];
+            Array.Copy(romData, processedRom, romData.Length);
+
+            // Find all SDD1 signatures in the rom and store them
+            using (MemoryStream ms = new MemoryStream(romData))
+            {
+                using (BinaryReader br = new BinaryReader(ms, new ASCIIEncoding()))
+                {
+                    // Continue reading SDD1 pointer data until we run out
+                    while (true)
+                    {
+                        long index = br.BaseStream.Position;
+
+                        if (index + SDD1_SIGNATURE.Length >= br.BaseStream.Length)
+                        {
+                            break;
+                        }
+
+                        byte[] signatureBuffer = br.ReadBytes(SDD1_SIGNATURE.Length);
+
+                        // If we didn't find a signature at this location, seek to the next character and restart the loop
+                        if (!signatureBuffer.SequenceEqual(SDD1_SIGNATURE))
+                        {
+                            br.BaseStream.Seek(-3, SeekOrigin.Current);
+                            continue;
+                        }
+
+                        // Store the pointer location in the rom (pointerLocation) and the
+                        // offset in the rawSdd1Data (dataLocation)
+                        // We must add the sdd1DataOffset to the read location offset to get to the right
+                        // position in the rawSdd1Data (appendedData)
+                        sdd1Pointers.Add(new Sdd1Pointer(index, br.ReadUInt32LE() + sdd1DataOffset));
+
+                        // Set the previous data length based on the current offset - the last offset
+                        if (sdd1Pointers.Count > 1)
+                        {
+                            sdd1Pointers[sdd1Pointers.Count - 2].dataLength = sdd1Pointers[sdd1Pointers.Count - 1].dataLocation - sdd1Pointers[sdd1Pointers.Count - 2].dataLocation;
+                        }
+                    }
+                }
+            }
+
+            if (sdd1Pointers.Count == 0)
+            {
+                Console.WriteLine("No S-DD1 data found, continuing...");
+                return processedRom;
+            }
+
+            sdd1Pointers[sdd1Pointers.Count - 1].dataLength = rawSdd1Data.Length - sdd1Pointers[sdd1Pointers.Count - 1].dataLocation;
+
+            Console.WriteLine("{0} S-DD1 pointers found", sdd1Pointers.Count);
+            Console.WriteLine("Reading S-DD1 data into memory...");
+
+            Compressor compressor = new Compressor();
+
+            byte[] outBuffer = new byte[0x40000];
+
+            // Find the decompressed data for each pointer, compress it, and replace the first 8 bytes of each pointer location (SDD1UINT becomes the compressed data)
+            foreach (var sdd1ptr in sdd1Pointers)
+            {
+                // Read the decompressed data
+                byte[] decompressedData = new byte[sdd1ptr.dataLength];
+                using (MemoryStream ms = new MemoryStream(rawSdd1Data))
+                {
+                    using (BinaryReader br = new BinaryReader(ms, new ASCIIEncoding()))
+                    {
+                        br.BaseStream.Seek(sdd1ptr.dataLocation, SeekOrigin.Begin);
+                        decompressedData = br.ReadBytes((int)sdd1ptr.dataLength);
+                    }
+                }
+
+                // Compress the decompressed data
+                uint outLength = 0;
+                byte[] compressedData = compressor.Compress(decompressedData, out outLength, outBuffer);
+
+                // Replace with the recompressed data
+                using (MemoryStream msb = new MemoryStream(processedRom))
+                {
+                    using (BinaryWriter bw = new BinaryWriter(msb, new ASCIIEncoding()))
+                    {
+                        bw.BaseStream.Seek(sdd1ptr.pointerLocation, SeekOrigin.Begin);
+                        bw.Write(compressedData, 0, (int)outLength);
+                    }
+                }
+            }
+
+            Console.WriteLine("Replaced all S-DD1 pointers with compressed S-DD1 data");
+
+            return processedRom;
+        }
+    }
+}

--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -8,7 +8,7 @@ namespace WiiuVcExtractor
 {
     class Program
     {
-        private const string WIIU_VC_EXTRACTOR_VERSION = "0.9.0";
+        private const string WIIU_VC_EXTRACTOR_VERSION = "1.0.0";
 
         static void PrintUsage()
         {

--- a/WiiuVcExtractor/Properties/AssemblyInfo.cs
+++ b/WiiuVcExtractor/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("WiiuVcExtractor")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/WiiuVcExtractor/WiiuVcExtractor.csproj
+++ b/WiiuVcExtractor/WiiuVcExtractor.csproj
@@ -62,8 +62,16 @@
     <Compile Include="FileTypes\RpxSectionHeaderSort.cs" />
     <Compile Include="Libraries\EndianUtility.cs" />
     <Compile Include="Libraries\RomSizeDictionary.cs" />
+    <Compile Include="Libraries\Sdd1\BitplanesExtractor.cs" />
+    <Compile Include="Libraries\Sdd1\Compressor.cs" />
+    <Compile Include="Libraries\Sdd1\ContextModel.cs" />
+    <Compile Include="Libraries\Sdd1\GolombCodeEncoder.cs" />
+    <Compile Include="Libraries\Sdd1\Interleaver.cs" />
+    <Compile Include="Libraries\Sdd1\ProbabilityEstimationModule.cs" />
+    <Compile Include="Libraries\Sdd1\Sdd1Pointer.cs" />
     <Compile Include="Libraries\SnesPcmExtractor.cs" />
     <Compile Include="Libraries\RomNameDictionary.cs" />
+    <Compile Include="Libraries\SnesSdd1Extractor.cs" />
     <Compile Include="RomExtractors\GbaVcExtractor.cs" />
     <Compile Include="RomExtractors\DsVcExtractor.cs" />
     <Compile Include="RomExtractors\IRomExtractor.cs" />


### PR DESCRIPTION
Fixes #50.

Add S-DD1 compressor logic based on Andreas Naive's work with S-DD1 in
C++.

If S-DD1 data is detected in a given SNES rom, it will be read in from
the extracted RPX file, recompressed, and injected back into the rom. At
the moment this should only impact Street Fighter Alpha 2.