### PR TITLE
Catch S-DD1 errors

### DIFF
--- a/WiiuVcExtractor/Program.cs
+++ b/WiiuVcExtractor/Program.cs
@@ -11,7 +11,7 @@
     /// </summary>
     public class Program
     {
-        private const string WiiUVcExtractorVersion = "2.0.0";
+        private const string WiiUVcExtractorVersion = "2.0.1";
 
         /// <summary>
         /// Prints usage information.

--- a/WiiuVcExtractor/Properties/AssemblyInfo.cs
+++ b/WiiuVcExtractor/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]

--- a/WiiuVcExtractor/RomExtractors/SnesVcExtractor.cs
+++ b/WiiuVcExtractor/RomExtractors/SnesVcExtractor.cs
@@ -267,7 +267,22 @@
 
                             // Seek to the S-DD1 data offset and read the S-DD1 header (if any)
                             br.BaseStream.Seek(this.romPosition - VcHeaderSize + this.sdd1Offset, SeekOrigin.Begin);
-                            this.sdd1DataOffset = br.ReadUInt32LE();
+
+                            try
+                            {
+                                this.sdd1DataOffset = br.ReadUInt32LE();
+                            }
+                            catch (Exception ex)
+                            {
+                                if (this.verbose)
+                                {
+                                    Console.WriteLine(
+                                        "Could not read the S-DD1 data offset, setting the offset to 0 to skip decompression. Error details: {0}",
+                                        ex.Message);
+                                }
+
+                                this.sdd1DataOffset = 0;
+                            }
 
                             Console.WriteLine("File size is 0x{0:X}", this.fileSize);
                             Console.WriteLine("Virtual Console Title offset is 0x{0:X}", this.vcNamePosition);


### PR DESCRIPTION
Commit e40e4b5ba2199d7c686dc5205806fd9fdb3b678e caused a regression in
SNES extraction where some small roms cannot be extracted when an S-DD1
header cannot be found.

This change ensures we catch this exception and assume the S-DD1 header
does not exist in those cases.

Fixes #55 